### PR TITLE
fix: robust button selector

### DIFF
--- a/public/ultimate-button-controller.js
+++ b/public/ultimate-button-controller.js
@@ -1163,19 +1163,21 @@ class UltimateButtonController {
         console.log('🎯 Attaching all buttons...');
         
         // Find all clickable elements
-        const clickableElements = document.querySelectorAll(`
-            button, 
-            [role="button"], 
-            .btn, 
-            .button, 
-            [onclick], 
-            [data-action],
-            .input-method,
-            .view-control,
-            .modal-close,
-            .nav-action,
-            .sidebar-toggle
-        `);
+        const selectorList = [
+            'button',
+            '[role="button"]',
+            '.btn',
+            '.button',
+            '[onclick]',
+            '[data-action]',
+            '.input-method',
+            '.view-control',
+            '.modal-close',
+            '.nav-action',
+            '.sidebar-toggle'
+        ].join(', ');
+
+        const clickableElements = document.querySelectorAll(selectorList);
         
         let attachedCount = 0;
         


### PR DESCRIPTION
## Summary
- build a selector list and join for `querySelectorAll` so buttons are reliably found

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689fa9ea425c83308142bf805a2e85ac