### PR TITLE
fix: initialize app and refresh sidebar

### DIFF
--- a/public/application-manager.js
+++ b/public/application-manager.js
@@ -201,10 +201,20 @@ class ApplicationManager {
         
         // Log to API if available
         const apiClient = this.managers.get('api');
-        if (apiClient) {
-            apiClient.logError(error, type).catch(() => {
-                // Ignore logging errors
+        if (apiClient && typeof apiClient.logClientError === 'function') {
+            const payload = {
+                message: error?.message || error?.toString?.() || 'Unknown error',
+                stack: error?.stack,
+                type
+            };
+            apiClient.logClientError(payload).catch(() => {
+                // Ignore logging errors to keep app stable
             });
+        }
+
+        // Notify user without breaking flow
+        if (window.legacyShowNotification) {
+            window.legacyShowNotification('Сталася внутрішня помилка. Деталі в консолі.', 'error');
         }
     }
     

--- a/tests/clients-api.test.js
+++ b/tests/clients-api.test.js
@@ -1,0 +1,49 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import express from 'express';
+import clientsRoutes from '../routes/clients.js';
+
+// Use in-memory database for isolation
+process.env.DB_PATH = ':memory:';
+process.env.NODE_ENV = 'test';
+process.env.OPENAI_API_KEY = 'test';
+
+let server;
+let base;
+
+// Start express server before tests
+
+test.before(() => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/clients', clientsRoutes);
+  server = app.listen(0);
+  const { port } = server.address();
+  base = `http://127.0.0.1:${port}`;
+});
+
+// Close server after tests
+
+test.after(() => {
+  server.close();
+});
+
+// Test client creation and listing
+
+test('client is returned in sidebar list after save', async () => {
+  const createRes = await fetch(`${base}/api/clients`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ company: 'TestCo' })
+  });
+  assert.equal(createRes.status, 200);
+  const createData = await createRes.json();
+  assert.equal(createData.success, true);
+
+  const listRes = await fetch(`${base}/api/clients`);
+  assert.equal(listRes.status, 200);
+  const listData = await listRes.json();
+  assert.equal(listData.success, true);
+  assert.equal(listData.clients.length, 1);
+  assert.equal(listData.clients[0].company, 'TestCo');
+});


### PR DESCRIPTION
## Summary
- re-query sidebar elements so saved clients render instantly
- expose `init` as `window.initializeApp` so ApplicationManager completes setup
- add API test verifying saved clients appear in listings

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint configuration not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fa9ea425c83308142bf805a2e85ac