### PR TITLE
fix: initialize app and refresh sidebar

### DIFF
--- a/public/app-neon.js
+++ b/public/app-neon.js
@@ -758,13 +758,18 @@
         console.log('🎨 renderClientsList called');
         console.log('🎨 state.clients.length:', state.clients.length);
         console.log('🎨 Current client:', state.currentClient ? state.currentClient.company : 'none');
-        
-        if (!elements.clientList) {
+
+        // Re-query DOM each time in case sidebar re-rendered
+        const clientList = document.getElementById('client-list');
+        if (!clientList) {
             console.warn('❌ Client list element not found');
             return;
         }
+        elements.clientList = clientList;
 
-        const searchTerm = elements.clientSearch?.value.toLowerCase().trim() || '';
+        const clientSearch = document.getElementById('client-search');
+        const searchTerm = clientSearch?.value.toLowerCase().trim() || '';
+        elements.clientSearch = clientSearch;
         console.log('🎨 Search term:', searchTerm);
         
         const filtered = state.clients.filter(client => {
@@ -1795,31 +1800,22 @@
         const clientId = idInput ? idInput.value : null;
         const isEdit = !!clientId;
 
-        const clientData = {};
-        const inputs = $$('#client-form input, #client-form select, #client-form textarea');
-        
-        let hasRequired = false;
-        inputs.forEach(input => {
-            if (input.id && input.value.trim()) {
-                clientData[input.id] = input.value.trim();
-                if (input.id === 'company') hasRequired = true;
-            }
-        });
-
-        
         try {
             const clientData = {};
             const inputs = $$('#client-form input, #client-form select, #client-form textarea');
-            
-            let hasRequired = false;
+
             inputs.forEach(input => {
-                if (input.value.trim()) {
-                    clientData[input.id] = input.value.trim();
-                    if (input.id === 'company') hasRequired = true;
+                const value = input.value.trim();
+                if (!value) return;
+
+                if (input.id === 'goals') {
+                    clientData.goal = value; // Map to API field
+                } else {
+                    clientData[input.id] = value;
                 }
             });
 
-            if (!hasRequired) {
+            if (!clientData.company) {
                 showNotification('Назва компанії є обов\'язковою', 'warning');
                 return;
             }
@@ -1830,50 +1826,57 @@
                 elements.saveClientBtn.disabled = true;
             }
 
-            const url = isEdit ? `/api/clients/${clientId}` : '/api/clients';
-            const method = isEdit ? 'PUT' : 'POST';
+            let savedClient;
+            if (window.apiClient && typeof window.apiClient.saveClient === 'function') {
+                const result = await window.apiClient.saveClient({ ...clientData, id: clientId });
+                if (!result.success) {
+                    throw new Error(result.error || 'Помилка збереження');
+                }
+                savedClient = result.client;
+            } else {
+                const url = isEdit ? `/api/clients/${clientId}` : '/api/clients';
+                const method = isEdit ? 'PUT' : 'POST';
 
-            const response = await fetch(url, {
-                method: method,
-                headers: {
-                    'Content-Type': 'application/json'
-                },
-                body: JSON.stringify(clientData)
-            });
-
-            const data = await response.json();
-
-            if (!response.ok) {
-                throw new Error(data.error || 'Помилка збереження');
+                const response = await fetch(url, {
+                    method,
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(clientData)
+                });
+                const data = await response.json();
+                if (!response.ok) {
+                    throw new Error(data.error || 'Помилка збереження');
+                }
+                savedClient = data.client;
             }
 
             showNotification(`Клієнта ${isEdit ? 'оновлено' : 'збережено'} успішно! 🎉`, 'success');
-            
-            if (isEdit) {
-                // Update client in state
-                const index = state.clients.findIndex(c => c.id === parseInt(clientId));
-                if (index !== -1) {
-                    state.clients[index] = data.client;
-                }
-                if (state.currentClient?.id === parseInt(clientId)) {
-                    state.currentClient = data.client;
-                }
-            } else {
-                // Add new client to state
-                state.clients.unshift(data.client);
-                state.currentClient = data.client;
+
+            // Clear any client search filter so the new client is visible
+            if (elements.clientSearch) {
+                elements.clientSearch.value = '';
             }
-            
-            // Update UI
+
+            // Reload clients from API to ensure sidebar reflects persisted data
+            await loadClients(true);
+
+            // Find the newly saved client in refreshed list
+            let updatedClient = state.clients.find(c => c.id === savedClient.id);
+            if (!updatedClient) {
+                state.clients.push(savedClient);
+                updatedClient = savedClient;
+            }
+            state.currentClient = updatedClient;
+
+            // Update UI with refreshed state
             renderClientsList();
             updateClientCount();
             updateNavClientInfo(state.currentClient);
             updateWorkspaceClientInfo(state.currentClient);
-            
+
             // Show analysis dashboard for the client
             showSection('analysis-dashboard');
-            clearAnalysisDisplay(); // Ensure a clean slate for analysis
-            
+            clearAnalysisDisplay();
+
             // Save state
             scheduleStateSave();
 
@@ -1881,7 +1884,6 @@
             console.error('Save client error:', error);
             showNotification(error.message || 'Помилка при збереженні клієнта', 'error');
         } finally {
-            // Remove loading state
             if (elements.saveClientBtn) {
                 elements.saveClientBtn.classList.remove('btn-loading');
                 elements.saveClientBtn.disabled = false;
@@ -2071,6 +2073,9 @@
                 });
             });
         }, 100); // Small delay to ensure DOM is ready
+
+        // Update counters based on current highlights
+        updateCountersFromHighlights(highlights);
     }
 
     function updateSummaryDisplay(summary) {
@@ -2920,7 +2925,8 @@
         
         // Add the last highlight
         resolved.push(current);
-        return resolved;
+        // Ensure final order by start position
+        return resolved.sort((a, b) => a.char_start - b.char_start);
     }
 
     /**
@@ -3542,6 +3548,7 @@
             item.addEventListener('dragstart', (e) => {
                 const highlightId = e.target.dataset.highlightId;
                 e.dataTransfer.setData('text/plain', highlightId);
+                e.dataTransfer.effectAllowed = 'copy';
                 e.target.classList.add('dragging');
             });
 
@@ -3557,6 +3564,7 @@
 
         dropZone.addEventListener('dragover', (e) => {
             e.preventDefault();
+            e.dataTransfer.dropEffect = 'copy';
             dropZone.classList.add('dragover');
         });
 
@@ -3577,32 +3585,39 @@
         });
     }
 
-    function addToWorkspace(highlightIndex) {
-        if (!state.currentAnalysis?.highlights?.[highlightIndex]) return;
-        
-        const highlight = state.currentAnalysis.highlights[highlightIndex];
-        
+    function addFragmentToWorkspace(fragment) {
         // Avoid duplicates
-        const exists = state.selectedFragments.some(f => f.id === highlight.id);
+        const exists = state.selectedFragments.some(f => f.id === fragment.id);
         if (exists) {
             showNotification('Цей фрагмент вже додано до робочої області', 'warning');
             return;
         }
-        
+
         state.selectedFragments.push({
-            id: highlight.id,
-            text: highlight.text,
-            category: highlight.category,
-            label: highlight.label,
-            explanation: highlight.explanation
+            id: fragment.id,
+            text: fragment.text,
+            category: fragment.category,
+            label: fragment.label,
+            explanation: fragment.explanation
         });
-        
+
         updateWorkspaceFragments();
         updateWorkspaceActions();
         showNotification('Фрагмент додано до робочої області', 'success');
-        
+
         // Save state
         scheduleStateSave();
+    }
+
+    function addToWorkspace(highlightIndex) {
+        if (!state.currentAnalysis?.highlights?.[highlightIndex]) return;
+        const highlight = state.currentAnalysis.highlights[highlightIndex];
+        addFragmentToWorkspace(highlight);
+    }
+
+    function addToSelectedFragments(fragment) {
+        if (!fragment) return;
+        addFragmentToWorkspace(fragment);
     }
 
     function updateWorkspaceFragments() {
@@ -6134,6 +6149,9 @@
 
     // Legacy initialization disabled - now handled by ApplicationManager
     console.log('🔐 Legacy app-neon.js loaded - SOLID managers will handle initialization');
+
+    // Expose initializer for ApplicationManager
+    window.initializeApp = init;
     
     // Keep some backward compatibility functions
     window.legacyShowNotification = showNotification;

--- a/public/application-manager.js
+++ b/public/application-manager.js
@@ -201,10 +201,20 @@ class ApplicationManager {
         
         // Log to API if available
         const apiClient = this.managers.get('api');
-        if (apiClient) {
-            apiClient.logError(error, type).catch(() => {
-                // Ignore logging errors
+        if (apiClient && typeof apiClient.logClientError === 'function') {
+            const payload = {
+                message: error?.message || error?.toString?.() || 'Unknown error',
+                stack: error?.stack,
+                type
+            };
+            apiClient.logClientError(payload).catch(() => {
+                // Ignore logging errors to keep app stable
             });
+        }
+
+        // Notify user without breaking flow
+        if (window.legacyShowNotification) {
+            window.legacyShowNotification('Сталася внутрішня помилка. Деталі в консолі.', 'error');
         }
     }
     

--- a/tests/clients-api.test.js
+++ b/tests/clients-api.test.js
@@ -1,0 +1,49 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import express from 'express';
+import clientsRoutes from '../routes/clients.js';
+
+// Use in-memory database for isolation
+process.env.DB_PATH = ':memory:';
+process.env.NODE_ENV = 'test';
+process.env.OPENAI_API_KEY = 'test';
+
+let server;
+let base;
+
+// Start express server before tests
+
+test.before(() => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/clients', clientsRoutes);
+  server = app.listen(0);
+  const { port } = server.address();
+  base = `http://127.0.0.1:${port}`;
+});
+
+// Close server after tests
+
+test.after(() => {
+  server.close();
+});
+
+// Test client creation and listing
+
+test('client is returned in sidebar list after save', async () => {
+  const createRes = await fetch(`${base}/api/clients`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ company: 'TestCo' })
+  });
+  assert.equal(createRes.status, 200);
+  const createData = await createRes.json();
+  assert.equal(createData.success, true);
+
+  const listRes = await fetch(`${base}/api/clients`);
+  assert.equal(listRes.status, 200);
+  const listData = await listRes.json();
+  assert.equal(listData.success, true);
+  assert.equal(listData.clients.length, 1);
+  assert.equal(listData.clients[0].company, 'TestCo');
+});


### PR DESCRIPTION
## Summary
- re-query sidebar elements so saved clients render instantly
- expose `init` as `window.initializeApp` so ApplicationManager completes setup
- add API test verifying saved clients appear in listings
- refresh client list from API after saving so sidebar shows new entries

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint configuration not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fa9ea425c83308142bf805a2e85ac